### PR TITLE
Stub at static linking

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -54,7 +54,4 @@ fn main() {
             println!("cargo:rustc-link-arg=-Wl,-rpath,{}", &s_path);
         }
     }
-
-    println!("cargo:rustc-link-lib=stdc++");
-    println!("cargo:rustc-link-lib=std");
 }

--- a/libasi/build.rs
+++ b/libasi/build.rs
@@ -34,16 +34,16 @@ fn main() {
     let paths = [
         {
             if let Some(a) = arch {
-                std::fs::canonicalize(format!("./vendored/camera/{}/{}", os, a))
+                std::fs::canonicalize(format!("../vendored/camera/{}/{}", os, a))
             } else {
-                std::fs::canonicalize(format!("./vendored/camera/{}", os))
+                std::fs::canonicalize(format!("../vendored/camera/{}", os))
             }
         },
         {
             if let Some(a) = arch {
-                std::fs::canonicalize(format!("./vendored/efw/{}/{}", os, a))
+                std::fs::canonicalize(format!("../vendored/efw/{}/{}", os, a))
             } else {
-                std::fs::canonicalize(format!("./vendored/efw/{}", os))
+                std::fs::canonicalize(format!("../vendored/efw/{}", os))
             }
         },
     ];
@@ -55,6 +55,9 @@ fn main() {
         }
     }
 
+    
+    println!("cargo:rustc-link-lib=static=EFWFilter");
+    println!("cargo:rustc-link-lib=static=ASICamera2");
     println!("cargo:rustc-link-lib=stdc++");
-    println!("cargo:rustc-link-lib=std");
+    println!("cargo:rustc-link-lib=usb-1.0");
 }


### PR DESCRIPTION
This wants to be a first attempt at trying to eliminate dependencies on ASI SDK (so they won't need to be installed)

A preliminary build on my machine `linux astroarch 5.18.3-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 09 Jun 2022 16:14:10 +0000 x86_64 GNU/Linux` against `ldd` shows the following output:

```
➜  asi-rs git:(mattia/static-linking) ldd target/debug/asi_ccd
	linux-vdso.so.1 (0x00007ffef4f94000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007fb160000000)
	libusb-1.0.so.0 => /usr/lib/libusb-1.0.so.0 (0x00007fb16126b000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007fb16124b000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007fb160319000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007fb15fc00000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fb1612af000)
	libudev.so.1 => /usr/lib/libudev.so.1 (0x00007fb16121b000)
	libatomic.so.1 => /usr/lib/libatomic.so.1 (0x00007fb161211000)
```

and

```
➜  asi-rs git:(mattia/static-linking) ✗ ldd target/debug/asi_efw
	linux-vdso.so.1 (0x00007fff9a9d7000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f3b9b600000)
	libudev.so.1 => /usr/lib/libudev.so.1 (0x00007f3b9c554000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f3b9c534000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007f3b9b919000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f3b9b200000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f3b9c5a7000)

```